### PR TITLE
Keysfirst

### DIFF
--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -178,6 +178,7 @@ class HomeRoute extends Route {
       i = i + 1;
       if(job.Function === "saltutil.find_job") continue;
       if(job.Function === "grains.items") continue;
+      if(job.Function === "wheel.key.list_all") continue;
 
       this._addJob(jobContainer, job);
       shown = shown + 1;

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -78,6 +78,10 @@ class HomeRoute extends Route {
 
   _updateOfflineMinion(container, hostname) {
     var element = document.getElementById(hostname);
+    if(element == null) {
+       console.log("offline minion not found on screen:", hostname);
+       return;
+    }
     while(element.firstChild) {
       element.removeChild(element.firstChild);
     }
@@ -94,6 +98,10 @@ class HomeRoute extends Route {
     var ip = minion.fqdn_ip4;
 
     var element = document.getElementById(minion.hostname);
+    if(element == null) {
+       console.log("online minion not found on screen:", minion.hostname);
+       return;
+    }
     while(element.firstChild) {
       element.removeChild(element.firstChild);
     }

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -201,6 +201,7 @@ class HomeRoute extends Route {
       if(job.Function === "saltutil.find_job") continue;
       if(job.Function === "grains.items") continue;
       if(job.Function === "wheel.key.list_all") continue;
+      if(job.Function === "runner.jobs.list_jobs") continue;
 
       this._addJob(jobContainer, job);
       shown = shown + 1;

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -27,7 +27,7 @@ class HomeRoute extends Route {
     var minions = data.return[0];
 
     var list = this.getElement().querySelector('#minions');
-    var hostnames = Object.keys(minions);
+    var hostnames = Object.keys(minions).sort();
 
     for(var i = 0; i < hostnames.length; i++) {
       var minion_info = minions[hostnames[i]];
@@ -47,7 +47,6 @@ class HomeRoute extends Route {
     var keys = data.return;
 
     var list = this.getElement().querySelector('#minions');
-    list.innerHTML = "";
 
     var hostnames = keys.minions.sort();
     for(var i = 0; i < hostnames.length; i++) {
@@ -79,8 +78,11 @@ class HomeRoute extends Route {
   _updateOfflineMinion(container, hostname) {
     var element = document.getElementById(hostname);
     if(element == null) {
-       console.log("offline minion not found on screen:", hostname);
-       return;
+      console.log("offline minion not found on screen:", hostname);
+      // construct a basic element that can be updated here
+      element = document.createElement('li');
+      element.id = hostname;
+      container.appendChild(element);
     }
     while(element.firstChild) {
       element.removeChild(element.firstChild);
@@ -99,8 +101,11 @@ class HomeRoute extends Route {
 
     var element = document.getElementById(minion.hostname);
     if(element == null) {
-       console.log("online minion not found on screen:", minion.hostname);
-       return;
+      console.log("online minion not found on screen:", minion.hostname);
+      // construct a basic element that can be updated here
+      element = document.createElement('li');
+      element.id = minion.hostname;
+      container.appendChild(element);
     }
     while(element.firstChild) {
       element.removeChild(element.firstChild);
@@ -124,6 +129,13 @@ class HomeRoute extends Route {
   }
 
   _addMinion(container, hostname) {
+
+    var element = document.getElementById(hostname);
+    if(element != null) {
+      console.log("minion already on screen:", hostname);
+      return;
+    }
+
     var element = document.createElement('li');
     element.id = hostname;
 

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -123,8 +123,10 @@ class HomeRoute extends Route {
 
     var minion = this._createDiv("accepted", "accepted");
     minion.id = "status";
-
     element.appendChild(minion);
+
+    element.appendChild(this._createDiv("os", "Loading..."));
+
     container.appendChild(element);
   }
 

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -115,7 +115,7 @@ class HomeRoute extends Route {
 
     element.appendChild(this._createDiv("hostname", hostname));
 
-    var rejected = this._createDiv("denied", "denied");
+    var rejected = this._createDiv("rejected", "rejected");
 
     element.appendChild(rejected);
     container.appendChild(element);
@@ -126,7 +126,7 @@ class HomeRoute extends Route {
 
     element.appendChild(this._createDiv("hostname", hostname));
 
-    var denied = this._createDiv("rejected", "rejected");
+    var denied = this._createDiv("denied", "denied");
 
     element.appendChild(denied);
     container.appendChild(element);

--- a/saltgui/static/stylesheets/home.css
+++ b/saltgui/static/stylesheets/home.css
@@ -106,6 +106,10 @@
   opacity: 1;
 }
 
+.minions li .accepted {
+  color: #00A000;
+}
+
 .minions li .denied {
   color: #FF00FF;
 }


### PR DESCRIPTION
Changed the main page so that it populates based on the salt-keys. Previously that was done based on the actual minion status retrieval. The updated method always provides a quick load of the page. Even when one or more minions are not reachable.
The visual effect is that the page first shows the key status (accepted/denied/unaccepted/rejected). The accepted state will then be replaced by the actual state of the minion.
Also fixed a mixup between the denied and rejected keys.