### PR TITLE
Added 'close' buttons on command+job windows

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -15,7 +15,7 @@
     <header>
       <h1 class='logo'>SaltGUI</h1>
       <div class='fab' id='button_manualrun'>&gt;_</div>
-      <div class='logout' id='button_logout'>logout</div>
+      <div class='nearlyvisiblebutton' id='button_logout'>logout</div>
     </header>
 
     <div class='route-container'>
@@ -51,6 +51,7 @@
 
       <div class='route' id='job'>
         <div class='panel job-info'>
+	  <div class='nearlyvisiblebutton' id='button_close_job'>close</div>
           <h1 class='function'></h1>
           <h2 class='time'></h2>
           <div class='hosts'></div>
@@ -61,6 +62,7 @@
 
     <div class='popup' id='run-command-popup'>
       <div class='run-command'>
+	<div class='nearlyvisiblebutton' id='button_close_cmd'>close</div>
         <h1>Manual Run</h1>
         <input id='target' type='text' placeholder="Target"/>
         <input id='command' type='text' placeholder="Command"/>

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -15,6 +15,8 @@ class API {
       .addEventListener('click', this._toggleManualRun);
     document.querySelector("#button_manualrun")
       .addEventListener('click', this._toggleManualRun);
+    document.querySelector("#button_close_cmd")
+      .addEventListener('click', this._toggleManualRun);
     document.querySelector("#button_logout")
       .addEventListener('click', _ => {
         this._logout(this);
@@ -70,7 +72,7 @@ class API {
     var isShowing = manualRun.style.display !== "none" && manualRun.style.display !== "";
 
     //Don't close if they click inside the window
-    if(isShowing && evt.target.className !== "popup") return;
+    if(isShowing && evt.target.className !== "popup" && evt.target.className !== "nearlyvisiblebutton") return;
     manualRun.style.display = isShowing ? "none" : "block";
     document.body.style["overflow-y"] = isShowing ? "scroll" : "hidden";
 
@@ -81,6 +83,7 @@ class API {
     if(isShowing && command.startsWith("salt.wheel.key.") && output != "Waiting for command...") {
       location.reload(); 
     }
+    evt.stopPropagation();
   }
 
   isAuthenticated() {

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -185,7 +185,7 @@ class HomeRoute extends Route {
     minion.id = "status";
     element.appendChild(minion);
 
-    element.appendChild(Route._createDiv("os", "Loading..."));
+    element.appendChild(Route._createDiv("os", "loading..."));
 
     var menu = new DropDownMenu(element);
     this._addMenuItemReject(menu, hostname);

--- a/saltgui/static/scripts/routes/home.js
+++ b/saltgui/static/scripts/routes/home.js
@@ -91,25 +91,25 @@ class HomeRoute extends Route {
   }
 
   _addMenuItemAccept(menu, hostname) {
-    menu.addMenuItem("Accept&nbsp;key", function(evt) {
+    menu.addMenuItem("Accept&nbsp;key...", function(evt) {
       this._runAcceptKey(evt, hostname);
     }.bind(this));
   }
 
   _addMenuItemDelete(menu, hostname) {
-    menu.addMenuItem("Delete&nbsp;key", function(evt) {
+    menu.addMenuItem("Delete&nbsp;key...", function(evt) {
       this._runDeleteKey(evt, hostname);
     }.bind(this));
   }
 
   _addMenuItemReject(menu, hostname) {
-    menu.addMenuItem("Reject&nbsp;key", function(evt) {
+    menu.addMenuItem("Reject&nbsp;key...", function(evt) {
       this._runRejectKey(evt, hostname);
     }.bind(this));
   }
 
   _addMenuItemSyncState(menu, hostname) {
-    menu.addMenuItem("Sync&nbsp;state", function(evt) {
+    menu.addMenuItem("Sync&nbsp;state...", function(evt) {
       this._runHighState(evt, hostname);
     }.bind(this));
   }

--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -21,6 +21,10 @@ class JobRoute extends Route {
     var info = data.info[0];
     job.getElement().querySelector(".hosts").innerHTML = "";
 
+    document.querySelector('#button_close_job').addEventListener('click', _ => {
+      this.router.goTo("/");
+    });
+
     var container = this.getElement().querySelector(".job-info");
     container.querySelector('.function').innerHTML = info.Function;
     container.querySelector('.time').innerHTML = info.StartTime;

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -57,16 +57,15 @@ h1 {
   opacity: 0.95;
 }
 
-.logout {
+.nearlyvisiblebutton {
   display: inline-block;
-  padding-top: 20px;
   float: right; 
   opacity: 0.3;
   font-size: 15px;
   font-weight: lighter;
 }
 
-.logout:hover {
+.nearlyvisiblebutton:hover {
   color: #4CAF50;
   opacity: 0.95;
   cursor: pointer;


### PR DESCRIPTION
Currently, the "command" popup can be closed by clicking outside the "command" window.
Currently, the "job" popup can be closed by clicking on the "SaltGUI" logo.
I've added "close" buttons, in the same style of the logout button, to do the same.
The benefit is of course that the user sees these actions.