### PR TITLE
Added support for generic EAUTH

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,6 +58,9 @@ This excellent frontend is originally written by [Oliver Dunk](https://github.co
 
 ## Changelog
 
+## 1.2.0 (2018-07-17)
+- Added support for alternative eauth methods [#23](https://github.com/maerteijn/SaltGUI/issues/26) (erwindon)
+
 ## 1.1.0 (2018-07-16)
 - Shows inactive minions as well (erwindon)
 - Switch to a more reliable grain indicating the ip-number (erwindon)

--- a/README.MD
+++ b/README.MD
@@ -58,9 +58,6 @@ This excellent frontend is originally written by [Oliver Dunk](https://github.co
 
 ## Changelog
 
-## 1.2.0 (2018-07-17)
-- Added support for alternative eauth methods (erwindon)
-
 ## 1.1.0 (2018-07-16)
 - Shows inactive minions as well (erwindon)
 - Switch to a more reliable grain indicating the ip-number (erwindon)

--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,7 @@ This excellent frontend is originally written by [Oliver Dunk](https://github.co
 ## Changelog
 
 ## 1.2.0 (2018-07-17)
-- Added support for alternative eauth methods [#23](https://github.com/maerteijn/SaltGUI/issues/26) (erwindon)
+- Added support for alternative eauth methods (erwindon)
 
 ## 1.1.0 (2018-07-16)
 - Shows inactive minions as well (erwindon)

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -37,17 +37,17 @@
               <!-- move items to this optgroup when at least -->
               <!-- one user reports a succesful use -->
               <option value="auto">auto</option>
+              <option value="file">file</option>
+              <option value="sharedsecret">sharedsecret</option>
+              <option value="yubico">yubico</option>
             </optgroup>
             <optgroup label="experimental" />
               <option value="django">django</option>
-              <option value="file">file</option>
               <option value="keystone">keystone</option>
               <option value="ldap">ldap</option>
               <option value="mysql">mysql</option>
               <option value="pki">pki</option>
               <option value="rest">rest</option>
-              <option value="sharedsecret">sharedsecret</option>
-              <option value="yubico">yubico</option>
             </optgroup>
           </select>
           <input type='submit' value='Login'/>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -28,18 +28,21 @@
           <input id='username' type='text' placeholder='Username' />
           <input id='password' type='password' placeholder='Password' />
           <select id='eauth'>
+            <!-- see https://docs.saltstack.com/en/latest/ref/auth/all/index.html -->
             <option id='eauth_default' value="default">Type</option>
             <optgroup label="standard" />
               <option value="pam">pam</option>
             </optgroup>
             <optgroup label="supported" />
-              <option value="ldap">ldap</option>
+              <!-- move items to this optgroup when at least -->
+              <!-- one user reports a succesful use -->
+              <option value="auto">auto</option>
             </optgroup>
             <optgroup label="experimental" />
-              <option value="auto">auto</option>
               <option value="django">django</option>
               <option value="file">file</option>
               <option value="keystone">keystone</option>
+              <option value="ldap">ldap</option>
               <option value="mysql">mysql</option>
               <option value="pki">pki</option>
               <option value="rest">rest</option>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -27,9 +27,29 @@
           </div>
           <input id='username' type='text' placeholder='Username' />
           <input id='password' type='password' placeholder='Password' />
+          <select id='eauth'>
+            <option id='eauth_default' value="default">Type</option>
+            <optgroup label="standard" />
+              <option value="pam">pam</option>
+            </optgroup>
+            <optgroup label="supported" />
+              <option value="ldap">ldap</option>
+            </optgroup>
+            <optgroup label="experimental" />
+              <option value="auto">auto</option>
+              <option value="django">django</option>
+              <option value="file">file</option>
+              <option value="keystone">keystone</option>
+              <option value="mysql">mysql</option>
+              <option value="pki">pki</option>
+              <option value="rest">rest</option>
+              <option value="sharedsecret">sharedsecret</option>
+              <option value="yubico">yubico</option>
+            </optgroup>
+          </select>
           <input type='submit' value='Login'/>
           <div class='attribution'>
-            <img src='static/images/github.png' />SaltGUI v1.1.0
+            <img src='static/images/github.png' />SaltGUI v1.2.0
           </div>
         </form>
       </div>
@@ -51,7 +71,7 @@
 
       <div class='route' id='job'>
         <div class='panel job-info'>
-	  <div class='nearlyvisiblebutton' id='button_close_job'>close</div>
+          <div class='nearlyvisiblebutton' id='button_close_job'>close</div>
           <h1 class='function'></h1>
           <h2 class='time'></h2>
           <div class='hosts'></div>
@@ -62,7 +82,7 @@
 
     <div class='popup' id='run-command-popup'>
       <div class='run-command'>
-	<div class='nearlyvisiblebutton' id='button_close_cmd'>close</div>
+        <div class='nearlyvisiblebutton' id='button_close_cmd'>close</div>
         <h1>Manual Run</h1>
         <input id='target' type='text' placeholder="Target"/>
         <input id='command' type='text' placeholder="Command"/>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -33,8 +33,8 @@
             <optgroup label="standard" />
               <option value="pam">pam</option>
             </optgroup>
-            <optgroup label="supported" />
-              <!-- move items to this optgroup when at least -->
+            <optgroup label="other" />
+              <!-- move items to this optgroup only when at least -->
               <!-- one user reports a succesful use -->
               <option value="auto">auto</option>
               <option value="file">file</option>
@@ -42,13 +42,11 @@
               <option value="yubico">yubico</option>
             </optgroup>
             <optgroup label="experimental" />
-              <option value="django">django</option>
-              <option value="keystone">keystone</option>
               <option value="ldap">ldap</option>
-              <option value="mysql">mysql</option>
-              <option value="pki">pki</option>
-              <option value="rest">rest</option>
             </optgroup>
+            <!-- other values are: django, keystone, mysql, pki, rest -->
+            <!-- these can be added after testing to optgroup 'other' -->
+            <!-- or to optgroup 'experimental' on explicit user request -->
           </select>
           <input type='submit' value='Login'/>
           <div class='attribution'>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -52,7 +52,7 @@
           </select>
           <input type='submit' value='Login'/>
           <div class='attribution'>
-            <img src='static/images/github.png' />SaltGUI v1.2.0
+            <img src='static/images/github.png' />SaltGUI v1.1.0
           </div>
         </form>
       </div>

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -115,8 +115,9 @@ class API {
 
     // overrule the eauth method when one is selected
     var type = document.querySelector("#login-form #eauth");
-    if(type.value !== "default")
+    if(type.value !== "default") {
       params.eauth = type.value;
+    }
     localStorage.setItem('logintype', type.value);
 
     return new Promise(function(resolve, reject) {

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -113,6 +113,12 @@ class API {
       eauth: "pam"
     };
 
+    // overrule the eauth method when one is selected
+    var type = document.querySelector("#login-form #eauth");
+    if(type.value !== "default")
+      params.eauth = type.value;
+    localStorage.setItem('logintype', type.value);
+
     return new Promise(function(resolve, reject) {
       api._callMethod("POST", "/login", params)
       .then(function(data) {

--- a/saltgui/static/scripts/routes/login.js
+++ b/saltgui/static/scripts/routes/login.js
@@ -12,6 +12,29 @@ class LoginRoute extends Route{
     this.registerEventListeners();
   }
 
+  updateTypeColor() {
+    var typeItem = document.querySelector("#login-form #eauth");
+    // make it look like a hint
+    if(typeItem.value === "default")
+      typeItem.style.color = "gray";
+    else
+      typeItem.style.color = "black";
+  }
+
+  onShow() {
+
+    var typeItem = document.querySelector("#login-form #eauth");
+
+    // restore login type
+    let typeValue = localStorage.getItem('logintype');
+    if(!typeValue) typeValue = "default";
+    typeItem.value = typeValue;
+
+    this.updateTypeColor();
+
+    typeItem.addEventListener('change', this.updateTypeColor);
+  }
+  
   registerEventListeners() {
     var submit = document.querySelector("#login-form");
     submit.addEventListener('submit', this.onLogin);
@@ -49,7 +72,6 @@ class LoginRoute extends Route{
   }
 
   onLoginFailure() {
-    //TODO: Show error
     this.toggleForm(true);
 
     var notice = document.querySelector('.notice-wrapper');

--- a/saltgui/static/stylesheets/login.css
+++ b/saltgui/static/stylesheets/login.css
@@ -22,14 +22,34 @@
   margin-bottom: 23px;
   font-weight: lighter;
   font-size: 60px;
+  width: 100%;
 }
 
 #login-form input {
+  width: 100%;
   font-size: 18px;
+}
+
+#login-form select {
+  width: 100%;
+  font-size: 14px;
 }
 
 #login-form input[type='success'] {
   width: 100%;
+}
+
+#login-form select {
+  color: black;
+}
+#login-form select option#eauth_default {
+  color: gray;
+}
+#login-form select option {
+  color: black;
+}
+#login-form select optgroup {
+  color: black;
 }
 
 .attribution {
@@ -69,5 +89,4 @@
   border-radius: 2px;
   text-align: center;
   font-size: 15px;
-  width:200px;
 }

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -121,7 +121,8 @@ h1 {
   margin-bottom: 20px;
 }
 
-input {
+input,
+select {
   display: block;
   padding: 7px 10px;
   margin-bottom: 15px;


### PR DESCRIPTION
Currently SaltGUI supports only PAM as authentication method.
This PR adds support for the other authentication methods.
A dropdown box is added to the login screen.
When nothing is entered, PAM is used as before.
The user's choice is persisted in the browser's local storage, so that on the next login, the default is usually already correct.
Regression tested with PAM implicitly selected. Tested with PAM explicitly selected. Tested also with AUTO, FILE, SHAREDSECRET and YUBICO. 