### PR TITLE
Added mysql as authentication method and retired auto and sharedsecret

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -36,16 +36,15 @@
             <optgroup label="other" />
               <!-- move items to this optgroup only when at least -->
               <!-- one user reports a succesful use -->
-              <option value="auto">auto</option>
               <option value="file">file</option>
               <option value="ldap">ldap</option>
               <option value="mysql">mysql</option>
-              <option value="sharedsecret">sharedsecret</option>
               <option value="yubico">yubico</option>
             </optgroup>
+            <!-- auto and sharedsecret already tested but not suitable for general use -->
             <!-- other values are: django, keystone, pki, rest -->
             <!-- these can be added after testing to optgroup 'other' -->
-            <!-- or to (new) optgroup 'experimental' on explicit user request -->
+            <!-- add untested values to (new) optgroup 'experimental' on explicit user request -->
           </select>
           <input type='submit' value='Login'/>
           <div class='attribution'>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -39,10 +39,11 @@
               <option value="auto">auto</option>
               <option value="file">file</option>
               <option value="ldap">ldap</option>
+              <option value="mysql">mysql</option>
               <option value="sharedsecret">sharedsecret</option>
               <option value="yubico">yubico</option>
             </optgroup>
-            <!-- other values are: django, keystone, mysql, pki, rest -->
+            <!-- other values are: django, keystone, pki, rest -->
             <!-- these can be added after testing to optgroup 'other' -->
             <!-- or to (new) optgroup 'experimental' on explicit user request -->
           </select>

--- a/saltgui/static/scripts/routes/login.js
+++ b/saltgui/static/scripts/routes/login.js
@@ -63,6 +63,7 @@ class LoginRoute extends Route{
 
     document.querySelector("#username").disabled = true;
     document.querySelector("#password").disabled = true;
+    document.querySelector("#eauth").disabled = true;
 
     notice.className = 'notice-wrapper';
     notice.focus(); //Used to trigger a reflow (to restart animation)


### PR DESCRIPTION
Added `mysql` as authentication method. It was tested with an actual mysql installation.
This one was not included in the previous PR on `pam` because it was a bit harder to test due to the additional setup.
Also disable the dropdown box just like use U/P fields.
Also retired `auto` and `sharedsecret` as these are (depending on actual use) a bit unsafe.
Btw, I see no reason to add further authentication methods at this moment.