### PR TITLE
Added ASYNC and BATCH capabilities

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -108,9 +108,9 @@
       <div class='run-command'>
         <div class='nearlyvisiblebutton' id='button_close_cmd'>&#x2715;</div>
         <h1>Manual Run</h1>
-        <input id='target' type='text' placeholder="Target"/>
-        <input id='command' type='text' placeholder="Command"/>
-        <input type='submit' value="Run command"/>
+        <div><input id='target' type='text' placeholder="Target"/></div>
+        <div><input id='command' type='text' placeholder="Command"/></div>
+        <div id="runblock"><input id="run_command" type='submit' value="Run command"/></div>
         <div id="cmd_error"></div>
         <pre class='output'>Waiting for command...</pre>
       </div>

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -55,21 +55,25 @@ class API {
     m.addMenuItem("Normal", this._setRunTypeNormal);
     m.addMenuItem("Async", this._setRunTypeAsync);
     m.addMenuItem("Batch", this._setRunTypeBatch);
-    m.addMenuItem("BatchWaitNone", this._setRunTypeBatchWaitNone);
-    m.addMenuItem("BatchWait1s", this._setRunTypeBatchWait1);
-    m.addMenuItem("BatchWait2s", this._setRunTypeBatchWait2);
-    m.addMenuItem("BatchWait3s", this._setRunTypeBatchWait3);
-    m.addMenuItem("BatchWait5s", this._setRunTypeBatchWait5);
-    m.addMenuItem("BatchWait10s", this._setRunTypeBatchWait10);
-    m.addMenuItem("BatchWait30s", this._setRunTypeBatchWait30);
-    m.addMenuItem("BatchWait60s", this._setRunTypeBatchWait60);
-    m.addMenuItem("BatchSize1", this._setRunTypeBatchSize1);
-    m.addMenuItem("BatchSize2", this._setRunTypeBatchSize2);
-    m.addMenuItem("BatchSize3", this._setRunTypeBatchSize3);
-    m.addMenuItem("BatchSize5", this._setRunTypeBatchSize5);
-    m.addMenuItem("BatchSize10", this._setRunTypeBatchSize10);
-    m.addMenuItem("BatchSize10%", this._setRunTypeBatchSize10p);
-    m.addMenuItem("BatchSize25%", this._setRunTypeBatchSize25p);
+
+    var mw = new DropDownMenu(runblock);
+    mw.addMenuItem("BatchWaitNone", this._setRunTypeBatchWaitNone);
+    mw.addMenuItem("BatchWait1s", this._setRunTypeBatchWait1);
+    mw.addMenuItem("BatchWait2s", this._setRunTypeBatchWait2);
+    mw.addMenuItem("BatchWait3s", this._setRunTypeBatchWait3);
+    mw.addMenuItem("BatchWait5s", this._setRunTypeBatchWait5);
+    mw.addMenuItem("BatchWait10s", this._setRunTypeBatchWait10);
+    mw.addMenuItem("BatchWait30s", this._setRunTypeBatchWait30);
+    mw.addMenuItem("BatchWait60s", this._setRunTypeBatchWait60);
+
+    var ms = new DropDownMenu(runblock);
+    ms.addMenuItem("BatchSize1", this._setRunTypeBatchSize1);
+    ms.addMenuItem("BatchSize2", this._setRunTypeBatchSize2);
+    ms.addMenuItem("BatchSize3", this._setRunTypeBatchSize3);
+    ms.addMenuItem("BatchSize5", this._setRunTypeBatchSize5);
+    ms.addMenuItem("BatchSize10", this._setRunTypeBatchSize10);
+    ms.addMenuItem("BatchSize10%", this._setRunTypeBatchSize10p);
+    ms.addMenuItem("BatchSize25%", this._setRunTypeBatchSize25p);
 
     var jobRunType = Route._createDiv("jobRunType", "normal");
     jobRunType.style.display = "none";

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -91,9 +91,6 @@ class API {
     batchWait.style.display = "none";
     runblock.appendChild(batchWait);
 
-    var runTypeText = Route._createDiv("runTypeText", "");
-    runblock.appendChild(runTypeText);
-
     document.querySelector(".run-command input[type='submit']")
       .addEventListener('click', this._onRun);
   }
@@ -105,49 +102,45 @@ class API {
 
     // now that the menu is used show the menu title
     // this is much clearer when the Size/Wait menus are also shown
-    this.menuRunType.setTitle("Type");
 
-    var txt;
     switch(jobRunType) {
     case "normal":
+      this.menuRunType.setTitle("Normal");
       this.menuBatchSize.hideMenu();
       this.menuBatchWait.hideMenu();
-      // note that this text is initially not shown until
-      // the user explicitly selects "normal" again
-      txt = "Run command normally";
       break;
     case "async":
+      this.menuRunType.setTitle("Async");
       this.menuBatchSize.hideMenu();
       this.menuBatchWait.hideMenu();
-      txt = "Run command in the background";
       break;
     case "batch":
+      this.menuRunType.setTitle("Batch");
       this.menuBatchSize.showMenu();
       this.menuBatchWait.showMenu();
-      txt = "Run command in batches";
-      if(batchSize === "")
-        txt += " of 10%"
-      else if(batchSize.endsWith("%"))
-        txt += " of " + batchSize;
-      else if(batchSize === "1")
-        txt += " of " + batchSize + " job";
-      else
-        txt += " of " + batchSize + " jobs";
-      if(batchWait === "")
-        // do not initially show this part until
-        // the user explicitly makes a choice
-        txt += "";
-      else if(batchWait == "0")
-        txt += ", not waiting between batches";
-      else if(batchWait == "1")
-        txt += ", waiting " + batchWait + " second between batches";
-      else
-        txt += ", waiting " + batchWait + " seconds between batches"
+
+      if(batchSize === "") {
+        this.menuBatchSize.setTitle("Size 10%");
+      } else if(batchSize.endsWith("%")) {
+        this.menuBatchSize.setTitle("Size " + batchSize);
+      } else if(batchSize === "1") {
+        this.menuBatchSize.setTitle("Size " + batchSize + " job");
+      } else {
+        this.menuBatchSize.setTitle("Size " + batchSize + " jobs");
+      }
+
+      if(batchWait === "") {
+        this.menuBatchWait.setTitle("No wait");
+      } else if(batchWait == "0") {
+        this.menuBatchWait.setTitle("No wait");
+      } else if(batchWait == "1") {
+        this.menuBatchWait.setTitle("Wait " + batchWait + " second");
+      } else {
+        this.menuBatchWait.setTitle("Wait " + batchWait + " seconds");
+      }
+
       break;
     }
-
-    var runTypeText = document.querySelector(".runTypeText");
-    runTypeText.innerText = txt;
   }
 
   _setRunTypeBatchWaitNone() {

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -9,22 +9,22 @@ class API {
     this._onRun = this._onRun.bind(this);
     this._onRunReturn = this._onRunReturn.bind(this);
     this._setRunTypeAsync = this._setRunTypeAsync.bind(this);
-    this._setRunTypeBatch = this._setRunTypeBatch.bind(this);
     this._setRunTypeBatchSize1 = this._setRunTypeBatchSize1.bind(this);
-    this._setRunTypeBatchSize10 = this._setRunTypeBatchSize10.bind(this);
-    this._setRunTypeBatchSize10p = this._setRunTypeBatchSize10p.bind(this);
     this._setRunTypeBatchSize2 = this._setRunTypeBatchSize2.bind(this);
-    this._setRunTypeBatchSize25p = this._setRunTypeBatchSize25p.bind(this);
     this._setRunTypeBatchSize3 = this._setRunTypeBatchSize3.bind(this);
     this._setRunTypeBatchSize5 = this._setRunTypeBatchSize5.bind(this);
+    this._setRunTypeBatchSize10 = this._setRunTypeBatchSize10.bind(this);
+    this._setRunTypeBatchSize10p = this._setRunTypeBatchSize10p.bind(this);
+    this._setRunTypeBatchSize25p = this._setRunTypeBatchSize25p.bind(this);
+    this._setRunTypeBatch = this._setRunTypeBatch.bind(this);
+    this._setRunTypeBatchWaitNone = this._setRunTypeBatchWaitNone.bind(this);
     this._setRunTypeBatchWait1 = this._setRunTypeBatchWait1.bind(this);
-    this._setRunTypeBatchWait10 = this._setRunTypeBatchWait10.bind(this);
     this._setRunTypeBatchWait2 = this._setRunTypeBatchWait2.bind(this);
     this._setRunTypeBatchWait3 = this._setRunTypeBatchWait3.bind(this);
-    this._setRunTypeBatchWait30 = this._setRunTypeBatchWait30.bind(this);
     this._setRunTypeBatchWait5 = this._setRunTypeBatchWait5.bind(this);
+    this._setRunTypeBatchWait10 = this._setRunTypeBatchWait10.bind(this);
+    this._setRunTypeBatchWait30 = this._setRunTypeBatchWait30.bind(this);
     this._setRunTypeBatchWait60 = this._setRunTypeBatchWait60.bind(this);
-    this._setRunTypeBatchWaitNone = this._setRunTypeBatchWaitNone.bind(this);
     this._setRunTypeNormal = this._setRunTypeNormal.bind(this);
 
     this._registerEventListeners();
@@ -51,29 +51,33 @@ class API {
     } );
 
     var runblock = document.getElementById("runblock");
-    var m = new DropDownMenu(runblock);
-    m.addMenuItem("Normal", this._setRunTypeNormal);
-    m.addMenuItem("Async", this._setRunTypeAsync);
-    m.addMenuItem("Batch", this._setRunTypeBatch);
+    this.menuRunType = new DropDownMenu(runblock);
+    this.menuRunType.addMenuItem("Normal", this._setRunTypeNormal);
+    this.menuRunType.addMenuItem("Async", this._setRunTypeAsync);
+    this.menuRunType.addMenuItem("Batch", this._setRunTypeBatch);
 
-    var mw = new DropDownMenu(runblock);
-    mw.addMenuItem("BatchWaitNone", this._setRunTypeBatchWaitNone);
-    mw.addMenuItem("BatchWait1s", this._setRunTypeBatchWait1);
-    mw.addMenuItem("BatchWait2s", this._setRunTypeBatchWait2);
-    mw.addMenuItem("BatchWait3s", this._setRunTypeBatchWait3);
-    mw.addMenuItem("BatchWait5s", this._setRunTypeBatchWait5);
-    mw.addMenuItem("BatchWait10s", this._setRunTypeBatchWait10);
-    mw.addMenuItem("BatchWait30s", this._setRunTypeBatchWait30);
-    mw.addMenuItem("BatchWait60s", this._setRunTypeBatchWait60);
+    this.menuBatchSize = new DropDownMenu(runblock);
+    this.menuBatchSize.setTitle("Batch&nbsp;Size");
+    this.menuBatchSize.addMenuItem("10%", this._setRunTypeBatchSize10p);
+    this.menuBatchSize.addMenuItem("25%", this._setRunTypeBatchSize25p);
+    this.menuBatchSize.addMenuItem("1", this._setRunTypeBatchSize1);
+    this.menuBatchSize.addMenuItem("2", this._setRunTypeBatchSize2);
+    this.menuBatchSize.addMenuItem("3", this._setRunTypeBatchSize3);
+    this.menuBatchSize.addMenuItem("5", this._setRunTypeBatchSize5);
+    this.menuBatchSize.addMenuItem("10", this._setRunTypeBatchSize10);
+    this.menuBatchSize.hideMenu();
 
-    var ms = new DropDownMenu(runblock);
-    ms.addMenuItem("BatchSize1", this._setRunTypeBatchSize1);
-    ms.addMenuItem("BatchSize2", this._setRunTypeBatchSize2);
-    ms.addMenuItem("BatchSize3", this._setRunTypeBatchSize3);
-    ms.addMenuItem("BatchSize5", this._setRunTypeBatchSize5);
-    ms.addMenuItem("BatchSize10", this._setRunTypeBatchSize10);
-    ms.addMenuItem("BatchSize10%", this._setRunTypeBatchSize10p);
-    ms.addMenuItem("BatchSize25%", this._setRunTypeBatchSize25p);
+    this.menuBatchWait = new DropDownMenu(runblock);
+    this.menuBatchWait.setTitle("Batch&nbsp;Wait");
+    this.menuBatchWait.addMenuItem("None", this._setRunTypeBatchWaitNone);
+    this.menuBatchWait.addMenuItem("1 second", this._setRunTypeBatchWait1);
+    this.menuBatchWait.addMenuItem("2 seconds", this._setRunTypeBatchWait2);
+    this.menuBatchWait.addMenuItem("3 seconds", this._setRunTypeBatchWait3);
+    this.menuBatchWait.addMenuItem("5 seconds", this._setRunTypeBatchWait5);
+    this.menuBatchWait.addMenuItem("10 seconds", this._setRunTypeBatchWait10);
+    this.menuBatchWait.addMenuItem("30 seconds", this._setRunTypeBatchWait30);
+    this.menuBatchWait.addMenuItem("60 seconds", this._setRunTypeBatchWait60);
+    this.menuBatchWait.hideMenu();
 
     var jobRunType = Route._createDiv("jobRunType", "normal");
     jobRunType.style.display = "none";
@@ -94,35 +98,49 @@ class API {
       .addEventListener('click', this._onRun);
   }
 
-  _updaterunTypeText() {
+  _updateRunTypeText() {
     var jobRunType = document.querySelector(".jobRunType").innerText;
     var batchWait = document.querySelector(".batchWait").innerText;
     var batchSize = document.querySelector(".batchSize").innerText;
 
+    // now that the menu is used show the menu title
+    // this is much clearer when the Size/Wait menus are also shown
+    this.menuRunType.setTitle("Type");
+
     var txt;
     switch(jobRunType) {
     case "normal":
-      txt = "run command normally (default)";
+      this.menuBatchSize.hideMenu();
+      this.menuBatchWait.hideMenu();
+      // note that this text is initially not shown until
+      // the user explicitly selects "normal" again
+      txt = "Run command normally";
       break;
     case "async":
-      txt = "run command in the background";
+      this.menuBatchSize.hideMenu();
+      this.menuBatchWait.hideMenu();
+      txt = "Run command in the background";
       break;
     case "batch":
-      txt = "run command in batches";
-      if(!batchSize)
-        txt += " of 10% (default)"
+      this.menuBatchSize.showMenu();
+      this.menuBatchWait.showMenu();
+      txt = "Run command in batches";
+      if(batchSize === "")
+        txt += " of 10%"
       else if(batchSize.endsWith("%"))
         txt += " of " + batchSize;
       else if(batchSize === "1")
         txt += " of " + batchSize + " job";
       else
         txt += " of " + batchSize + " jobs";
-      if(!batchWait)
-        txt += ", not waiting between batches (default)"
+      if(batchWait === "")
+        // do not initially show this part until
+        // the user explicitly makes a choice
+        txt += "";
       else if(batchWait == "0")
-        txt += ", not waiting between batches"
+        txt += ", not waiting between batches";
       else if(batchWait == "1")
-        txt += ", waiting " + batchWait + " second between batches"
+        txt += ", waiting " + batchWait + " second between batches";
       else
         txt += ", waiting " + batchWait + " seconds between batches"
       break;
@@ -135,67 +153,67 @@ class API {
   _setRunTypeBatchWaitNone() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "0";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait1() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "1";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait2() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "2";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait3() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "3";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait5() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "5";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait10() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "10";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait30() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "30";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchWait60() {
     var batchWait = document.querySelector(".batchWait");
     batchWait.innerText = "60";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeNormal() {
     var jobRunType = document.querySelector(".jobRunType");
     jobRunType.innerText = "normal";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeAsync() {
     var jobRunType = document.querySelector(".jobRunType");
     jobRunType.innerText = "async";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatch() {
     var jobRunType = document.querySelector(".jobRunType");
     jobRunType.innerText = "batch";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize1() {
@@ -203,7 +221,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "1";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize2() {
@@ -211,6 +229,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "2";
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize3() {
@@ -218,7 +237,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "3";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize5() {
@@ -226,7 +245,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "5";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize10() {
@@ -234,7 +253,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "10";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize10p() {
@@ -242,7 +261,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "10%";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _setRunTypeBatchSize25p() {
@@ -250,7 +269,7 @@ class API {
     jobRunType.innerText = "batch";
     var batchSize = document.querySelector(".batchSize");
     batchSize.innerText = "25%";
-    this._updaterunTypeText();
+    this._updateRunTypeText();
   }
 
   _onRun() {

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -8,6 +8,24 @@ class API {
     this._getRunParams = this._getRunParams.bind(this);
     this._onRun = this._onRun.bind(this);
     this._onRunReturn = this._onRunReturn.bind(this);
+    this._setRunTypeAsync = this._setRunTypeAsync.bind(this);
+    this._setRunTypeBatch = this._setRunTypeBatch.bind(this);
+    this._setRunTypeBatchSize1 = this._setRunTypeBatchSize1.bind(this);
+    this._setRunTypeBatchSize10 = this._setRunTypeBatchSize10.bind(this);
+    this._setRunTypeBatchSize10p = this._setRunTypeBatchSize10p.bind(this);
+    this._setRunTypeBatchSize2 = this._setRunTypeBatchSize2.bind(this);
+    this._setRunTypeBatchSize25p = this._setRunTypeBatchSize25p.bind(this);
+    this._setRunTypeBatchSize3 = this._setRunTypeBatchSize3.bind(this);
+    this._setRunTypeBatchSize5 = this._setRunTypeBatchSize5.bind(this);
+    this._setRunTypeBatchWait1 = this._setRunTypeBatchWait1.bind(this);
+    this._setRunTypeBatchWait10 = this._setRunTypeBatchWait10.bind(this);
+    this._setRunTypeBatchWait2 = this._setRunTypeBatchWait2.bind(this);
+    this._setRunTypeBatchWait3 = this._setRunTypeBatchWait3.bind(this);
+    this._setRunTypeBatchWait30 = this._setRunTypeBatchWait30.bind(this);
+    this._setRunTypeBatchWait5 = this._setRunTypeBatchWait5.bind(this);
+    this._setRunTypeBatchWait60 = this._setRunTypeBatchWait60.bind(this);
+    this._setRunTypeBatchWaitNone = this._setRunTypeBatchWaitNone.bind(this);
+    this._setRunTypeNormal = this._setRunTypeNormal.bind(this);
 
     this._registerEventListeners();
   }
@@ -31,8 +49,204 @@ class API {
       .addEventListener('click', _ => {
         window.location.replace("/keys");
     } );
+
+    var runblock = document.getElementById("runblock");
+    var m = new DropDownMenu(runblock);
+    m.addMenuItem("Normal", this._setRunTypeNormal);
+    m.addMenuItem("Async", this._setRunTypeAsync);
+    m.addMenuItem("Batch", this._setRunTypeBatch);
+    m.addMenuItem("BatchWaitNone", this._setRunTypeBatchWaitNone);
+    m.addMenuItem("BatchWait1s", this._setRunTypeBatchWait1);
+    m.addMenuItem("BatchWait2s", this._setRunTypeBatchWait2);
+    m.addMenuItem("BatchWait3s", this._setRunTypeBatchWait3);
+    m.addMenuItem("BatchWait5s", this._setRunTypeBatchWait5);
+    m.addMenuItem("BatchWait10s", this._setRunTypeBatchWait10);
+    m.addMenuItem("BatchWait30s", this._setRunTypeBatchWait30);
+    m.addMenuItem("BatchWait60s", this._setRunTypeBatchWait60);
+    m.addMenuItem("BatchSize1", this._setRunTypeBatchSize1);
+    m.addMenuItem("BatchSize2", this._setRunTypeBatchSize2);
+    m.addMenuItem("BatchSize3", this._setRunTypeBatchSize3);
+    m.addMenuItem("BatchSize5", this._setRunTypeBatchSize5);
+    m.addMenuItem("BatchSize10", this._setRunTypeBatchSize10);
+    m.addMenuItem("BatchSize10%", this._setRunTypeBatchSize10p);
+    m.addMenuItem("BatchSize25%", this._setRunTypeBatchSize25p);
+
+    var jobRunType = Route._createDiv("jobRunType", "normal");
+    jobRunType.style.display = "none";
+    runblock.appendChild(jobRunType);
+
+    var batchSize = Route._createDiv("batchSize", "");
+    batchSize.style.display = "none";
+    runblock.appendChild(batchSize);
+
+    var batchWait = Route._createDiv("batchWait", "");
+    batchWait.style.display = "none";
+    runblock.appendChild(batchWait);
+
+    var runTypeText = Route._createDiv("runTypeText", "");
+    runblock.appendChild(runTypeText);
+
     document.querySelector(".run-command input[type='submit']")
       .addEventListener('click', this._onRun);
+  }
+
+  _updaterunTypeText() {
+    var jobRunType = document.querySelector(".jobRunType").innerText;
+    var batchWait = document.querySelector(".batchWait").innerText;
+    var batchSize = document.querySelector(".batchSize").innerText;
+
+    var txt;
+    switch(jobRunType) {
+    case "normal":
+      txt = "run command normally (default)";
+      break;
+    case "async":
+      txt = "run command in the background";
+      break;
+    case "batch":
+      txt = "run command in batches";
+      if(!batchSize)
+        txt += " of 10% (default)"
+      else if(batchSize.endsWith("%"))
+        txt += " of " + batchSize;
+      else if(batchSize === "1")
+        txt += " of " + batchSize + " job";
+      else
+        txt += " of " + batchSize + " jobs";
+      if(!batchWait)
+        txt += ", not waiting between batches (default)"
+      else if(batchWait == "0")
+        txt += ", not waiting between batches"
+      else if(batchWait == "1")
+        txt += ", waiting " + batchWait + " second between batches"
+      else
+        txt += ", waiting " + batchWait + " seconds between batches"
+      break;
+    }
+
+    var runTypeText = document.querySelector(".runTypeText");
+    runTypeText.innerText = txt;
+  }
+
+  _setRunTypeBatchWaitNone() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "0";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait1() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "1";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait2() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "2";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait3() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "3";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait5() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "5";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait10() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "10";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait30() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "30";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchWait60() {
+    var batchWait = document.querySelector(".batchWait");
+    batchWait.innerText = "60";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeNormal() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "normal";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeAsync() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "async";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatch() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchSize1() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "1";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchSize2() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "2";
+  }
+
+  _setRunTypeBatchSize3() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "3";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchSize5() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "5";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchSize10() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "10";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchSize10p() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "10%";
+    this._updaterunTypeText();
+  }
+
+  _setRunTypeBatchSize25p() {
+    var jobRunType = document.querySelector(".jobRunType");
+    jobRunType.innerText = "batch";
+    var batchSize = document.querySelector(".batchSize");
+    batchSize.innerText = "25%";
+    this._updaterunTypeText();
   }
 
   _onRun() {
@@ -53,12 +267,16 @@ class API {
   }
 
   _onRunReturn(data) {
-    var response = data.return[0];
-    var hostnames = Object.keys(response);
-
     var outputContainer = document.querySelector(".run-command pre");
     outputContainer.innerHTML = "";
 
+    // collate all output, so that it can be presented in alphabetic order
+    var response = { };
+    for(var r of data.return)
+      for(var h in r)
+        response[h] = r[h];
+
+    var hostnames = Object.keys(response).sort();
     for(var i = 0; i < hostnames.length; i++) {
       var hostname = hostnames[i];
 
@@ -217,6 +435,21 @@ class API {
       params.fun = functionToRun;
       params.tgt = target;
       if(args.length !== 0) params.arg = args;
+    }
+
+    var jobRunType = document.querySelector(".jobRunType");
+    if(params.client === "local" && jobRunType.innerText === "async") {
+      params.client = "local_async";
+      // return looks like:
+      // { "jid": "20180718173942195461", "minions": [ ... ] }
+    }
+    if(params.client === "local" && jobRunType.innerText === "batch") {
+      params.client = "local_batch";
+      // TODO
+      params.batch = "10%";
+      // TODO
+      params.batch_wait = 3;
+      // it returns the actual output in a group of batches
     }
 
     return this._callMethod("POST", "/", params);

--- a/saltgui/static/scripts/dropdown.js
+++ b/saltgui/static/scripts/dropdown.js
@@ -4,18 +4,17 @@ class DropDownMenu {
   // The visual clue for the menu is added to the given element
   constructor(element) {
     this.menuDropdown = Route._createDiv("run-command-button", "");
-    var menuButton;
     if(element.id === "header") {
       // 8801 = MATHEMATICAL OPERATOR IDENTICAL TO (aka "hamburger")
-      menuButton = Route._createDiv("menu-dropdown", "&#8801;");
+      this.menuButton = Route._createDiv("menu-dropdown", "&#8801;");
       this.menuDropdown.classList.add("hamburger");
     } else {
       // 9658 = BLACK RIGHT-POINTING POINTER
-      menuButton = Route._createDiv("menu-dropdown", "&#9658;");
+      this.menuButton = Route._createDiv("menu-dropdown", "&#9658;");
       // hide the menu until it receives menu-items
       this.menuDropdown.style.display = "none";
     }
-    this.menuDropdown.appendChild(menuButton);
+    this.menuDropdown.appendChild(this.menuButton);
     this.menuDropdownContent = Route._createDiv("menu-dropdown-content", "");
     this.menuDropdown.appendChild(this.menuDropdownContent);
     element.appendChild(this.menuDropdown);
@@ -33,6 +32,18 @@ class DropDownMenu {
       // css code which will otherwise be overruled
       this.menuDropdown.style.display = "inline-block";
     }
+  }
+
+  setTitle(title) {
+    this.menuButton.innerHTML = title + "&nbsp;&#9658;";
+  }
+
+  showMenu() {
+    this.menuDropdown.style.display = "inline-block";
+  }
+
+  hideMenu() {
+    this.menuDropdown.style.display = "none";
   }
 
 }

--- a/saltgui/static/stylesheets/dropdown.css
+++ b/saltgui/static/stylesheets/dropdown.css
@@ -1,6 +1,7 @@
 /* The container <div> - needed to position the menu-dropdown content */
 .menu-dropdown {
     padding: 5px 20px 5px 20px;
+    cursor: pointer;
 }
 
 header .menu-dropdown {
@@ -30,6 +31,7 @@ header .menu-dropdown-content {
     clear: both;
     margin: 3px;
     padding: 5px 20px 5px 20px;
+    cursor: pointer;
 }
 
 /* Change color of menu-dropdown links on hover */

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -161,7 +161,7 @@ h1 {
 
 input,
 select {
-  display: inline-block;
+  display: block;
   padding: 7px 10px;
   margin-bottom: 15px;
   border-radius: 2px;

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -161,7 +161,7 @@ h1 {
 
 input,
 select {
-  display: block;
+  display: inline-block;
   padding: 7px 10px;
   margin-bottom: 15px;
   border-radius: 2px;

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -181,7 +181,7 @@ input[type='submit'] {
   background-color: #4CAF50;
   color: white;
   border: 0;
-  margin-top: 25px;
+  margin-top: 5px;
   cursor: pointer;
   box-shadow: 0px 4px 2px rgba(33, 33, 33, 0.2);
   transition: box-shadow 0.2s;


### PR DESCRIPTION
Current functionality for the "Manual Run" box is to run a command synchronously. i.e. you wait until the command is complete. For some commands that may be a bit long. For different reasons, you may want to run the jobs piecewise on servers instead of all at once.
The PR add a drop-down box (initially only the menu triangle next to the "Run command" button) with the options Normal, Async and Batch. Once used, the selection remains visible. When Batch is selected, 2 additional drop-down menus are shown. That makes it possible to select the batch-size and the waiting time for starting new jobs. These 2 menu's only contain some fixed choices to keep things simple.
When the job is started as Async, a simple confirmation is shown listing the jobid (in a future PR the jobid becomes a link to the job page).
When the job is started as Batch, the system waits until all tasks are completed. No progress is show (as before). The results are combined and presented as if the job was started normally. This is a limitation of the API. (in a future PR this might become an incremental update with a progress indicator, when the salt message bus is eavesdropped).
These options are silently ignored when WHEEL or RUNNER functions are used.