### PR TITLE
added sanity checks for startup of runtests.sh

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This script is a BASH script, therefore the interpreter must be BASH
+[ "$BASH" != "" ] || { echo "$0: must use bash"; exit 1; }
+
+# Docker must be started as root, therefore this script must run as root
+[ "$UID" = "0" ] || { echo "$0: must be root"; exit 1; }
+
 # always cleanup the docker images when something goes wrong
 function cleanupdocker {
     docker-compose -f docker/docker-compose.yml rm -f -s

--- a/runtests.sh
+++ b/runtests.sh
@@ -3,9 +3,6 @@
 # This script is a BASH script, therefore the interpreter must be BASH
 [ "$BASH" != "" ] || { echo "$0: must use bash"; exit 1; }
 
-# Docker must be started as root, therefore this script must run as root
-[ "$UID" = "0" ] || { echo "$0: must be root"; exit 1; }
-
 # always cleanup the docker images when something goes wrong
 function cleanupdocker {
     docker-compose -f docker/docker-compose.yml rm -f -s


### PR DESCRIPTION
Every time I run this script I get it wrong 2 times:
1) not using `bash`; and
2) not using `sudo`

It takes a few seconds and a bit of output before the script fails.
Therefore this update to let the script fail-fast.