### PR TITLE
use only iterations instead of indexing

### DIFF
--- a/saltgui/static/scripts/router.js
+++ b/saltgui/static/scripts/router.js
@@ -31,8 +31,7 @@ class Router {
   goTo(path) {
     if(this.switchingRoute) return;
     if(window.location.pathname === path && this.currentRoute) return;
-    for(let i = 0; i < this.routes.length; i++) {
-      const route = this.routes[i];
+    for(const route of this.routes) {
       if(!route.getPath().test(path.split("?")[0])) continue;
 
       window.history.pushState({}, undefined, path);

--- a/saltgui/static/scripts/routes/keys.js
+++ b/saltgui/static/scripts/routes/keys.js
@@ -31,32 +31,32 @@ class KeysRoute extends PageRoute {
 
     let list = this.getPageElement().querySelector('#minions');
     let hostnames = keys.minions.sort();
-    for(let i = 0; i < hostnames.length; i++) {
-      this._addMinion(list, hostnames[i]);
+    for(const hostname of hostnames) {
+      this._addMinion(list, hostname);
     }
     if(hostnames.length === 0)
       this._addNone(list);
 
     list = this.getPageElement().querySelector('#keys_denied');
     hostnames = keys.minions_denied.sort();
-    for(let i = 0; i < hostnames.length; i++) {
-      this._addDeniedMinion(list, hostnames[i]);
+    for(const hostname of hostnames) {
+      this._addDeniedMinion(list, hostname);
     }
     if(hostnames.length === 0)
       this._addNone(list);
 
     list = this.getPageElement().querySelector('#keys_unaccepted');
     hostnames = keys.minions_pre.sort();
-    for(let i = 0; i < hostnames.length; i++) {
-      this._addPreMinion(list, hostnames[i]);
+    for(const hostname of hostnames) {
+      this._addPreMinion(list, hostname);
     }
     if(hostnames.length === 0)
       this._addNone(list);
 
     list = this.getPageElement().querySelector('#keys_rejected');
     hostnames = keys.minions_rejected.sort();
-    for(let i = 0; i < hostnames.length; i++) {
-      this._addRejectedMinion(list, hostnames[i]);
+    for(const hostname of hostnames) {
+      this._addRejectedMinion(list, hostname);
     }
     if(hostnames.length === 0)
       this._addNone(list);

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -30,8 +30,8 @@ class MinionsRoute extends PageRoute {
     const list = this.getPageElement().querySelector('#minions');
 
     const hostnames = keys.minions.sort();
-    for(let i = 0; i < hostnames.length; i++) {
-      this._addMinion(list, hostnames[i]);
+    for(const hostname of hostnames) {
+      this._addMinion(list, hostname);
     }
 
     this.keysLoaded = true;

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -26,15 +26,14 @@ class PageRoute extends Route {
     const list = this.getPageElement().querySelector('#minions');
     const hostnames = Object.keys(minions).sort();
 
-    for(let i = 0; i < hostnames.length; i++) {
-      const minion_info = minions[hostnames[i]];
+    for(const hostname of hostnames) {
+      const minion_info = minions[hostname];
 
       // minions can be offline, then the info will be false
       if (minion_info === false) {
-        this._updateOfflineMinion(list, hostnames[i]);
+        this._updateOfflineMinion(list, hostname);
       } else {
-        const minion = minions[hostnames[i]];
-        this._updateMinion(list, minion, hostnames[i]);
+        this._updateMinion(list, minion_info, hostname);
       }
     }
   }
@@ -169,8 +168,7 @@ class PageRoute extends Route {
     const keys = Object.keys(jobs);
     const newArray = [];
 
-    for(let i = 0; i < keys.length; i++) {
-      const key = keys[i];
+    for(const key of keys) {
       const job = jobs[key];
       job.id = key;
       newArray.push(job);

--- a/saltgui/static/scripts/utils.js
+++ b/saltgui/static/scripts/utils.js
@@ -43,10 +43,10 @@ window.createElement = function(type, className, content) {
 window.getQueryParam = function(name) {
   const vars = [];
   const hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-  for(let i = 0; i < hashes.length; i++) {
-    const hash = hashes[i].split('=');
-    vars.push(hash[0]);
-    if(hash[0] === name) return hash[1];
+  for(const hash of hashes) {
+    const hashparts = hash.split('=');
+    vars.push(hashparts[0]);
+    if(hashparts[0] === name) return hashparts[1];
   }
   return undefined;
 };


### PR DESCRIPTION
Some for-loops still use explicit indexing to access all list/array members, while the index itself is not used for anything else. In modern JS, this can be done in a more elegant way.
This PR converts all loops to more iteration-style loops.

e.g.
from:
`for(let i = 0; i < hostnames.length; i++) this._addMinion(list, hostnames[i]);`
to:
`for(const hostname of hostnames) this._addMinion(list, hostname);`
