### PR TITLE
do not add hostname as a grain

### DIFF
--- a/saltgui/static/scripts/routes/keys.js
+++ b/saltgui/static/scripts/routes/keys.js
@@ -96,14 +96,14 @@ class KeysRoute extends PageRoute {
     this._addMenuItemDelete(menu, hostname, "");
   }
 
-  _updateMinion(container, minion) {
-    super._updateMinion(container, minion);
+  _updateMinion(container, minion, hostname) {
+    super._updateMinion(container, minion, hostname);
 
-    const element = document.getElementById(minion.hostname);
+    const element = document.getElementById(hostname);
 
     const menu = new DropDownMenu(element);
-    this._addMenuItemReject(menu, minion.hostname, " include_accepted=true");
-    this._addMenuItemDelete(menu, minion.hostname, "");
+    this._addMenuItemReject(menu, hostname, " include_accepted=true");
+    this._addMenuItemDelete(menu, hostname, "");
   }
 
   _addRejectedMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -44,12 +44,12 @@ class MinionsRoute extends PageRoute {
     }.bind(this));
   }
 
-  _updateMinion(container, minion) {
-    super._updateMinion(container, minion);
+  _updateMinion(container, minion, hostname) {
+    super._updateMinion(container, minion, hostname);
 
-    const element = document.getElementById(minion.hostname);
+    const element = document.getElementById(hostname);
     const menu = new DropDownMenu(element);
-    this._addMenuItemSyncState(menu, minion.hostname);
+    this._addMenuItemSyncState(menu, hostname);
   }
 
 }

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -34,8 +34,7 @@ class PageRoute extends Route {
         this._updateOfflineMinion(list, hostnames[i]);
       } else {
         const minion = minions[hostnames[i]];
-        minion.hostname = hostnames[i];
-        this._updateMinion(list, minion);
+        this._updateMinion(list, minion, hostnames[i]);
       }
     }
   }
@@ -75,12 +74,12 @@ class PageRoute extends Route {
     element.appendChild(offline);
   }
 
-  _updateMinion(container, minion) {
+  _updateMinion(container, minion, hostname) {
     const ip = minion.fqdn_ip4;
 
-    const element = this._getElement(container, minion.hostname);
+    const element = this._getElement(container, hostname);
 
-    element.appendChild(Route._createDiv("hostname", minion.hostname));
+    element.appendChild(Route._createDiv("hostname", hostname));
 
     const address = Route._createDiv("status", ip);
     address.classList.add("address");


### PR DESCRIPTION
The current SaltGUI adds the hostname internally to the list of grains that it has retrieved from a minion. That makes to very hard to distinguish the actual list of grains later for more dedicated functionality.
This PR stops adding the hostname to the list of grains and starts passing the hostname as a proper parameter.