### PR TITLE
 show targettype+target on jobs panel and jobs page 

### DIFF
--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -28,7 +28,7 @@ class JobRoute extends Route {
     const container = this.getPageElement().querySelector(".job-info");
 
     let functionText = info.Function + " on ";
-    if(info["Target-type"] != "glob" && info["Target-type"] != "list") {
+    if(info["Target-type"] !== "glob" && info["Target-type"] !== "list") {
       // note that due to bug in 2018.3, all finished jobs
       // will be shown as if of type 'list'
       // therefore we suppress that one

--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -26,7 +26,19 @@ class JobRoute extends Route {
     });
 
     const container = this.getPageElement().querySelector(".job-info");
-    container.querySelector('.function').innerHTML = info.Function;
+
+    let functionText = info.Function + " on ";
+    if(info["Target-type"] != "glob" && info["Target-type"] != "list") {
+      // note that due to bug in 2018.3, all finished jobs
+      // will be shown as if of type 'list'
+      // therefore we suppress that one
+      functionText += info["Target-type"];
+    }
+    if(info.Target) {
+      functionText += info.Target;
+    }
+    container.querySelector('.function').innerHTML = functionText;
+
     container.querySelector('.time').innerHTML = info.StartTime;
 
     const hostnames = Object.keys(info.Result);

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -148,12 +148,25 @@ class PageRoute extends Route {
 
   _addJob(container, job) {
     const element = document.createElement('li');
-    element.id = job.id;
+    element.id = "job" + job.id;
 
-    element.appendChild(Route._createDiv("target", job.Target));
-    element.appendChild(Route._createDiv("function", job.Function));
-    element.appendChild(Route._createDiv("time", job.StartTime));
+    let targetText = job.Target;
+    if(job["Target-type"] !== "glob" && job["Target-type"] !== "list") {
+      // note that due to bug in 2018.3, all finished jobs
+      // will be shown as if of type 'list'
+      // therefore we suppress that one
+      targetText = job["Target-type"] + " " + targetText;
+    }
+    element.appendChild(Route._createDiv("target", targetText));
+
+    const functionText = job.Function;
+    element.appendChild(Route._createDiv("function", functionText));
+
+    const startTimeText = job.StartTime;
+    element.appendChild(Route._createDiv("time", startTimeText));
+
     container.appendChild(element);
+
     element.addEventListener('click', this._createJobListener(job.id));
   }
 


### PR DESCRIPTION
The jobs panel shows target+command+date, and not targettype. When zooming in on a job, the target is no longer shown. It is true that the list of minions is shown, but the information on how these were selected is no longer shown.
This PR shows the targettype+target in both the jobs panel (on pages "minions" and "keys"; and on the "job" page, which is reached after clicking on a job.
For simplicity, the words "glob" (the default) and "list" are suppressed.
Due to a bug in 2018.3, many jobs are stored as of type "list" while they were not. So that would have been the second reason not to show the indicator for targettype "list".