### PR TITLE
show progress of a long job

### DIFF
--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -172,6 +172,10 @@ class API {
     return this._callMethod("GET", "/jobs/" + id, {});
   }
 
+  getRunningJobs() {
+    return this._getRunParams(null, "runners.jobs.active");
+  }
+
   _showError(errorMessage) {
     const errLabel = document.querySelector("#cmd_error");
     errLabel.innerText = errorMessage;

--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -27,16 +27,8 @@ class JobRoute extends Route {
 
     const container = this.getPageElement().querySelector(".job-info");
 
-    let functionText = info.Function + " on ";
-    if(info["Target-type"] !== "glob" && info["Target-type"] !== "list") {
-      // note that due to bug in 2018.3, all finished jobs
-      // will be shown as if of type 'list'
-      // therefore we suppress that one
-      functionText += info["Target-type"];
-    }
-    if(info.Target) {
-      functionText += info.Target;
-    }
+    const functionText = info.Function + " on " +
+      window.makeTargetText(info["Target-type"], info.Target);
     container.querySelector('.function').innerHTML = functionText;
 
     container.querySelector('.time').innerHTML = info.StartTime;

--- a/saltgui/static/scripts/routes/keys.js
+++ b/saltgui/static/scripts/routes/keys.js
@@ -23,6 +23,7 @@ class KeysRoute extends PageRoute {
       keys.router.api.getMinions().then(keys._updateMinions);
       keys.router.api.getKeys().then(keys._updateKeys);
       keys.router.api.getJobs().then(keys._updateJobs);
+      keys.router.api.getRunningJobs().then(keys._runningJobs);
     });
   }
 

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -21,6 +21,7 @@ class MinionsRoute extends PageRoute {
       minions.router.api.getMinions().then(minions._updateMinions);
       minions.router.api.getKeys().then(minions._updateKeys);
       minions.router.api.getJobs().then(minions._updateJobs);
+      minions.router.api.getRunningJobs().then(minions._runningJobs);
     });
   }
 

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -155,13 +155,7 @@ class PageRoute extends Route {
       const job = jobs[k];
 
       // start with same text as for _addJob
-      let targetText = job.Target;
-      if(job["Target-type"] !== "glob" && job["Target-type"] !== "list") {
-        // note that due to bug in 2018.3, all finished jobs
-        // will be shown as if of type 'list'
-        // therefore we suppress that one
-        targetText = job["Target-type"] + " " + targetText;
-      }
+      let targetText = window.makeTargetText(job["Target-type"], job.Target);
 
       // then add the operational statistics
       if(job.Running.length > 0)

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -178,13 +178,7 @@ class PageRoute extends Route {
     const element = document.createElement('li');
     element.id = "job" + job.id;
 
-    let targetText = job.Target;
-    if(job["Target-type"] !== "glob" && job["Target-type"] !== "list") {
-      // note that due to bug in 2018.3, all finished jobs
-      // will be shown as if of type 'list'
-      // therefore we suppress that one
-      targetText = job["Target-type"] + " " + targetText;
-    }
+    const targetText = window.makeTargetText(job["Target-type"], job.Target);
     element.appendChild(Route._createDiv("target", targetText));
 
     const functionText = job.Function;

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -132,18 +132,46 @@ class PageRoute extends Route {
     while(shown < 7 && jobs[i] !== undefined) {
       const job = jobs[i];
       i = i + 1;
-      if(job.Function === "saltutil.find_job") continue;
       if(job.Function === "grains.items") continue;
-      if(job.Function === "wheel.key.list_all") continue;
+      if(job.Function === "runner.jobs.active") continue;
       if(job.Function === "runner.jobs.list_job") continue;
       if(job.Function === "runner.jobs.list_jobs") continue;
+      if(job.Function === "saltutil.find_job") continue;
+      if(job.Function === "saltutil.running") continue;
       if(job.Function === "sys.doc") continue;
+      if(job.Function === "wheel.key.list_all") continue;
 
       this._addJob(jobContainer, job);
       shown = shown + 1;
     }
     this.jobsLoaded = true;
     if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
+  }
+
+  _runningJobs(data) {
+    const jobs = data.return[0];
+    for(const k in jobs)
+    {
+      const job = jobs[k];
+
+      // start with same text as for _addJob
+      let targetText = job.Target;
+      if(job["Target-type"] !== "glob" && job["Target-type"] !== "list") {
+        // note that due to bug in 2018.3, all finished jobs
+        // will be shown as if of type 'list'
+        // therefore we suppress that one
+        targetText = job["Target-type"] + " " + targetText;
+      }
+
+      // then add the operational statistics
+      if(job.Running.length > 0)
+        targetText = targetText + ", " + job.Running.length + " running";
+      if(job.Returned.length > 0)
+        targetText = targetText + ", " + job.Returned.length + " returned";
+
+      const targetField = document.querySelector(".jobs #job" + k + " .target");
+      targetField.innerText = targetText;
+    }
   }
 
   _addJob(container, job) {

--- a/saltgui/static/scripts/utils.js
+++ b/saltgui/static/scripts/utils.js
@@ -56,3 +56,21 @@ window.escape = function(input) {
   div.appendChild(document.createTextNode(input));
   return div.innerHTML;
 };
+
+window.makeTargetText = function(targetType, targetPattern) {
+  // note that 'glob' is the most common case
+  // when used from the command-line, that target-type
+  // is not even specified.
+  // therefore we suppress that one
+
+  // note that due to bug in 2018.3, all finished jobs
+  // will be shown as if of type 'list'
+  // therefore we suppress that one
+
+  let returnText = "";
+  if(targetType !== "glob" && targetType !== "list") {
+    returnText = targetType + " ";
+  }
+  returnText += targetPattern;
+  return returnText;
+};

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -63,4 +63,58 @@ describe('Unittests for utils.js', function() {
     done();
   });
 
+  it('test makeTargetText', done => {
+
+    let result;
+
+    // list of target-types from:
+    // https://docs.saltstack.com/en/latest/ref/clients/index.html#salt.client.LocalClient.cmd
+
+    // glob - Bash glob completion - Default
+    result = window.makeTargetText("glob", "*");
+    assert.equal(result, "*");
+
+    // pcre - Perl style regular expression
+    result = window.makeTargetText("pcre", ".*");
+    assert.equal(result, "pcre .*");
+
+    // list - Python list of hosts
+    result = window.makeTargetText("list", "a,b,c");
+    assert.equal(result, "a,b,c");
+
+    // grain - Match based on a grain comparison
+    result = window.makeTargetText("grain", "os:*");
+    assert.equal(result, "grain os:*");
+
+    // grain_pcre - Grain comparison with a regex
+    result = window.makeTargetText("grain_pcre", "os:.*");
+    assert.equal(result, "grain_pcre os:.*");
+
+    // pillar - Pillar data comparison
+    result = window.makeTargetText("pillar", "p1:*");
+    assert.equal(result, "pillar p1:*");
+
+    // pillar_pcre - Pillar data comparison with a regex
+    result = window.makeTargetText("pillar_pcre", "p1:.*");
+    assert.equal(result, "pillar_pcre p1:.*");
+
+    // nodegroup - Match on nodegroup
+    result = window.makeTargetText("nodegroup", "ng3");
+    assert.equal(result, "nodegroup ng3");
+
+    // range - Use a Range server for matching
+    result = window.makeTargetText("range", "a-z");
+    assert.equal(result, "range a-z");
+
+    // compound - Pass a compound match string
+    result = window.makeTargetText("compound", "webserv* and G@os:Debian or E@web-dc1-srv.*");
+    assert.equal(result, "compound webserv* and G@os:Debian or E@web-dc1-srv.*");
+
+    // ipcidr - Match based on Subnet (CIDR notation) or IPv4 address.
+    result = window.makeTargetText("ipcidr", "10.0.0.0/24");
+    assert.equal(result, "ipcidr 10.0.0.0/24");
+
+    done();
+  });
+
 });


### PR DESCRIPTION
The jobs panel currently does not show any information about jobs that are still in progress. This PR adds the progress statistics for the jobs that are in progress. The number of running and the number of completed jobs is shown.
test with: start `salt '*' test.rand_sleep 300`. then refresh the SaltGUI screen.
note that this is static information, it is updated only on a screen refresh.

sample:
> ![afbeelding](https://user-images.githubusercontent.com/3663742/46039869-15d8cc80-c10f-11e8-9c38-9fbdcee1dcf5.png)