### PR TITLE
fixed array output

### DIFF
--- a/saltgui/static/scripts/output.js
+++ b/saltgui/static/scripts/output.js
@@ -104,6 +104,12 @@ class Output {
         return false;
       }
 
+      // arrays are also objects,
+      // but not what we are looking for
+      if(Array.isArray(output)) {
+        return false;
+      }
+
       for(const key of Object.keys(output)) {
         // e.g. for "test.rand_str"
         if(output[key] === null) {

--- a/tests/unit/output.js
+++ b/tests/unit/output.js
@@ -28,6 +28,11 @@ describe('Unittests for output.js', function() {
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isFalse(result);
 
+    // documentation is not text in a dict
+    outputData = { "host1": ["something"] };
+    result = Output.isDocumentationOutput(outputData, "keyword");
+    assert.isFalse(result);
+
     // documentation is not text
     outputData = { "host1": 123 };
     result = Output.isDocumentationOutput(outputData, "keyword");

--- a/tests/unit/output.js
+++ b/tests/unit/output.js
@@ -8,37 +8,37 @@ describe('Unittests for output.js', function() {
 
     let outputData, result;
 
-    // normal case
+    // ok, normal documentation case
     outputData = { "host1": {"keyword": "explanation"} };
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isTrue(result);
 
-    // does not match requested documentation
+    // wrong, does not match requested documentation
     outputData = { "host1": {"keyword": "explanation"} };
     result = Output.isDocumentationOutput(outputData, "another");
     assert.isFalse(result);
 
-    // no resulting documentation
+    // wrong, no resulting documentation
     outputData = { "host1": {"keyword": null} };
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isFalse(result);
 
-    // documentation is not text
+    // wrong, value is not text
     outputData = { "host1": {"keyword": 123} };
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isFalse(result);
 
-    // documentation is not text in a dict
+    // wrong, returned structure is not a dict
     outputData = { "host1": ["something"] };
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isFalse(result);
 
-    // documentation is not text
+    // wrong, returned structure is not a dict
     outputData = { "host1": 123 };
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isFalse(result);
 
-    // documentation is not text in a dictionary
+    // wrong, returned structure is not a dict
     outputData = { "host1": "hello" };
     result = Output.isDocumentationOutput(outputData, "keyword");
     assert.isFalse(result);


### PR DESCRIPTION
When issuing the `grains.ls` command, its output is mistaken for documentation output.
The documentation detector (in `output.js`) did not test for an object to actually being an array.
Now it does, and a unit test was added to prove it.