### PR TITLE
simplified reload-on-change

### DIFF
--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -85,10 +85,15 @@ class CommandBox {
 
     // test whether the command may have caused an update to the list
     // the user may have altered the text after running the command, just ignore that
-    const command = document.querySelector(".run-command #command").value;
+    const command = document.querySelector(".run-command #command").value.split(" ")[0];
     const output = document.querySelector(".run-command pre").innerHTML;
-    if(command.startsWith("wheel.key.") && output !== "Waiting for command...") {
-      location.reload();
+    const _screenModifyingCommands = [
+      "wheel.key.accept",
+      "wheel.key.delete",
+      "wheel.key.reject",
+    ];
+    if(_screenModifyingCommands.includes(command) && output !== "Waiting for command...") {
+      location.reload(); 
     }
 
     evt.stopPropagation();


### PR DESCRIPTION
When using the commandbox and running a command that may have altered the screen content, a screen refresh is done when the commandbox closes. The current implementation is simple and effective, but not easily extendible.
The current test basically tested for commands starting with `wheel.key.` using a simple `if` statement.
This PR replaces that test with a test against an explicit list. The list is easily extendible when new commands should be tested for.

Note that this mechanism remains a bit primitive:
* it works only on the last command executed: a `wheel.key.delete` followed by a `test.ping` in the same commandbox does not cause the screen refresh
* it works without considering the current page. but typically a command is only easily available from a page where it is relevant